### PR TITLE
Add missing semi-colon

### DIFF
--- a/ExportToLaravelMigration.spBundle/MigrationParser.php
+++ b/ExportToLaravelMigration.spBundle/MigrationParser.php
@@ -236,7 +236,7 @@ class MigrationParser
             $columns = $this->escapeArray($data['columns']);
             $temp .= '(' . $columns . ', \'' . $field . '\')';
 
-            $fields[$field] = $temp;
+            $fields[$field] = $temp . ';';
         }
 
         return $fields;


### PR DESCRIPTION
Hello,

I noticed that there was a missing semi-colon on indexes and uniques:

```php
// from users table
$table->unique('email', 'users_email_unique')

// from password resets table
$table->index('email', 'password_resets_email_index')
$table->index('token', 'password_resets_token_index')
```

This should fix it.