### PR TITLE
Fix #16 CURRENT_TIMESTAMP default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tsv
 /ExportToLaravelMigration.spBundle/0
+.idea
+.DS_Store

--- a/ExportToLaravelMigration.spBundle/MigrationParser.php
+++ b/ExportToLaravelMigration.spBundle/MigrationParser.php
@@ -220,6 +220,8 @@ class MigrationParser
                     $temp .= '->default(' . $data['default'] . ')';
                 } elseif ($method==='boolean') {
                     $temp .= '->default(' . ($data['default'] ? 'true' : 'false') . ')';
+                } elseif (strtolower(trim($data['default'])) === 'current_timestamp') {
+                    $temp .= '->default(\DB::raw(\'CURRENT_TIMESTAMP\'))';
                 } else {
                     $temp .= '->default(\'' . trim($data['default']) . '\')';
                 }


### PR DESCRIPTION
While setting default value as CURRENT_TIMESTAMP, DB::raw() must be used.
Otherwise the value will be accepted as string 'CURRENT_TIMESTAMP'.