### PR TITLE
FIX: enum field default value has duplicate quotes

### DIFF
--- a/ExportToLaravelMigration.spBundle/MigrationParser.php
+++ b/ExportToLaravelMigration.spBundle/MigrationParser.php
@@ -215,8 +215,8 @@ class MigrationParser
             if ($data['nullable']) {
                 $temp .= '->nullable()';
             }
-            if ($data['default']) {
-                if ($isNumeric) {
+            if (isset($data['default'])) {
+                if ($isNumeric || ($method === 'enum')) {
                     $temp .= '->default(' . $data['default'] . ')';
                 } elseif ($method==='boolean') {
                     $temp .= '->default(' . ($data['default'] ? 'true' : 'false') . ')';


### PR DESCRIPTION
- FIX: enum type fields default value is generated with duplicate quotes ex: `->default(''0'')`
- FIX: if default value is 0 the `default()` is not generated.