### PR TITLE
1.4.3

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 1
 :minor: 4
-:patch: 1
+:patch: 3
 :special: ''

--- a/ExportToLaravelMigration.spBundle/MigrationParser.php
+++ b/ExportToLaravelMigration.spBundle/MigrationParser.php
@@ -6,7 +6,7 @@ class MigrationParser
     /**
      * @var string
      */
-    protected $version = '1.4.1';
+    protected $version = '1.4.3';
 
     /**
      * @var array
@@ -351,7 +351,7 @@ class MigrationParser
                 unset($this->keys[$constraint]);
             }
 
-            $this->constraints[$constraint] = compact('colName', 'refTable', 'refColumn', 'updateRule', 'deleteRule');
+            $this->constraints[$constraint][] = compact('colName', 'refTable', 'refColumn', 'updateRule', 'deleteRule');
         }
     }
 
@@ -359,12 +359,13 @@ class MigrationParser
     {
         $fields = [];
         foreach ($this->constraints as $field => $data) {
-            $columns = $this->escapeArray($data['colName']);
-            $temp = '$table->foreign(' . $columns . ', \'' . $field . '\')' .
-                '->references(\'' . $data['refColumn'] . '\')' .
-                '->on(\'' . $data['refTable'] . '\')' .
-                '->onDelete(\'' . $data['deleteRule'] . '\')' .
-                '->onUpdate(\'' . $data['updateRule'] . '\')';
+            $colNames   = $this->escapeArray(array_map(function ($entry) { return $entry['colName']; }, $data));
+            $refColumns  = $this->escapeArray(array_map(function ($entry) { return $entry['refColumn']; }, $data));
+            $temp = '$table->foreign(' . $colNames . ', \'' . $field . '\')' .
+                '->references(' . $refColumns . ')' .
+                '->on(\'' . $data[0]['refTable'] . '\')' .
+                '->onDelete(\'' . $data[0]['deleteRule'] . '\')' .
+                '->onUpdate(\'' . $data[0]['updateRule'] . '\')';
 
             $fields[$field] = $temp . ';';
         }


### PR DESCRIPTION
There was a problem creating migrations of tables that had compound foreign keys. 
The script generated only the first relationship column.

I'm sorry again, my English. I used Google Translate