### PR TITLE
Including charset and collation for tables and columns

### DIFF
--- a/ExportToLaravelMigration.spBundle/create.stub
+++ b/ExportToLaravelMigration.spBundle/create.stub
@@ -21,8 +21,8 @@ class DummyClass extends Migration
             // structure
             // keys
             // constraints
+            // tableCollationAndCharset
         });
-
         // extras
     }
 

--- a/ExportToLaravelMigration.spBundle/parse.php
+++ b/ExportToLaravelMigration.spBundle/parse.php
@@ -7,7 +7,8 @@ $tableName = $argv[1];
 $m = new MigrationParser($tableName,
     __DIR__ . '/rowsStructure.tsv',
     __DIR__ . '/rowsKeys.tsv',
-    __DIR__ . '/rowsConstraints.tsv'
+    __DIR__ . '/rowsConstraints.tsv',
+    __DIR__ . '/rowsTableCharsetAndCollation.tsv'
 );
 
 echo $m->makeMigration();

--- a/ExportToLaravelMigration.spBundle/parse.sh
+++ b/ExportToLaravelMigration.spBundle/parse.sh
@@ -21,18 +21,18 @@ execute_sql()
     done
 
     # check for errors
-    if [ `cat $SP_QUERY_RESULT_STATUS_FILE` == 1 ]; then
+    if [ `cat "$SP_QUERY_RESULT_STATUS_FILE"` == 1 ]; then
         echo "<h2 class='err'>Query error:</h2><pre>"
-        cat $SP_QUERY_RESULT_FILE
+        cat "$SP_QUERY_RESULT_FILE"
         echo "</pre>"
         echo "<button onclick=\"window.system.closeHTMLOutputWindow()\">Close</button>"
-        exit $SP_BUNDLE_EXIT_SHOW_AS_HTML
+        exit "$SP_BUNDLE_EXIT_SHOW_AS_HTML"
     fi
 }
 
 # set up HTML styles
 echo "
-<style type="text/css">
+<style type=\"text/css\">
 body, button { font-size: 15px; }
 .err { color: #900; }
 pre { background: #eee; border: 1px solid #ddd; padding: 15px; }
@@ -51,7 +51,7 @@ clear_temp
 if [ -z "$SP_SELECTED_TABLES" ]; then
     echo "<h2 class='err'>Error</h2><p>No table selected.</p>"
     echo "<button onclick=\"window.system.closeHTMLOutputWindow()\">Close</button>"
-    exit $SP_BUNDLE_EXIT_SHOW_AS_HTML
+    exit "$SP_BUNDLE_EXIT_SHOW_AS_HTML"
 fi
 
 # build dest dir
@@ -61,7 +61,7 @@ if mkdir -p $DESTDIR; then
 else
     echo "<h2 class='err'>Error</h2><p>Could not create directory: <strong>$DESTDIR</strong></p>"
     echo "<button onclick=\"window.system.closeHTMLOutputWindow()\">Close</button>"
-    exit $SP_BUNDLE_EXIT_SHOW_AS_HTML
+    exit "$SP_BUNDLE_EXIT_SHOW_AS_HTML"
 fi
 
 CONSTRAINTS_TABLE="no"
@@ -100,7 +100,7 @@ do
 
     # execute and save the table structure result
     execute_sql
-    cp $SP_QUERY_RESULT_FILE "$SP_BUNDLE_PATH/rowsStructure.tsv"
+    cp "$SP_QUERY_RESULT_FILE" "$SP_BUNDLE_PATH/rowsStructure.tsv"
 
     clear_temp
 

--- a/ExportToLaravelMigration.spBundle/parse.sh
+++ b/ExportToLaravelMigration.spBundle/parse.sh
@@ -74,7 +74,7 @@ WHERE table_schema = 'information_schema'
 LIMIT 1;"  > "$SP_QUERY_FILE"
 execute_sql
 
-if [ `cat $SP_QUERY_RESULT_STATUS_FILE` > 0 ] && [[ $(wc -l < $SP_QUERY_RESULT_FILE) -ge 2 ]]; then
+if [ `cat "$SP_QUERY_RESULT_STATUS_FILE"` -gt 0 ] && [[ $(wc -l < "$SP_QUERY_RESULT_FILE") -ge 2 ]]; then
     CONSTRAINTS_TABLE="yes"
 fi
 clear_temp
@@ -134,7 +134,7 @@ do
 
     fi
 
-    if [ "$CONSTRAINTS_TABLE" == "yes" ] && [ `cat $SP_QUERY_RESULT_STATUS_FILE` > 0 ]; then
+    if [ "$CONSTRAINTS_TABLE" == "yes" ] && [ `cat "$SP_QUERY_RESULT_STATUS_FILE"` -gt 0 ]; then
         clear_temp
 
         # send CONSTRAINTS query to Sequel Pro

--- a/ExportToLaravelMigration.spBundle/parse.sh
+++ b/ExportToLaravelMigration.spBundle/parse.sh
@@ -90,7 +90,7 @@ do
     # get the table structure, including field comments
     echo "
     SELECT
-        COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_KEY, COLUMN_DEFAULT, EXTRA, COLUMN_COMMENT
+        COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_KEY, COLUMN_DEFAULT, CHARACTER_SET_NAME, COLLATION_NAME, EXTRA, COLUMN_COMMENT
     FROM
         information_schema.COLUMNS
     WHERE
@@ -109,7 +109,26 @@ do
 
     # execute and save the SHOW INDEXES result
     execute_sql
-    cp $SP_QUERY_RESULT_FILE "$SP_BUNDLE_PATH/rowsKeys.tsv"
+    cp "$SP_QUERY_RESULT_FILE" "$SP_BUNDLE_PATH/rowsKeys.tsv"
+
+    clear_temp
+
+    # get character set and collation name
+    echo "
+    SELECT
+	    CHARACTER_SET_NAME, TABLE_COLLATION
+    FROM
+      information_schema.TABLES, information_schema.COLLATION_CHARACTER_SET_APPLICABILITY
+    WHERE
+        COLLATION_NAME = TABLE_COLLATION
+    AND
+        TABLE_SCHEMA = '${SP_SELECTED_DATABASE}'
+    AND
+        TABLE_NAME = '${table}';" > "$SP_QUERY_FILE"
+
+    # execute and save the character set and collation name result
+    execute_sql
+    cp "$SP_QUERY_RESULT_FILE" "$SP_BUNDLE_PATH/rowsTableCharsetAndCollation.tsv"
 
     clear_temp
 


### PR DESCRIPTION
First of all, thank you for your project! It's saving me a lot of time in being able to bring migrations into a new project for an old database.

With this old database, many of the columns specify a charset or collation that differs from that of the table or schema. Likewise many of the tables have varying charsets/collations. I figured I'm not the only one to run into this situation.

As well, I made some small adjustments to the shell script, wrapping filenames in quotes and fixing a small bug for a conditional test. I also reduced some of the extra new lines in the resulting migration. And I made a minor bump in the version.

Hopefully this is something that can be helpful to others! Any feedback is appreciated.